### PR TITLE
Change dropIfExists to dropColumn

### DIFF
--- a/database/migrations/2016_09_11_000000_add_activation_fields_to_users.php
+++ b/database/migrations/2016_09_11_000000_add_activation_fields_to_users.php
@@ -17,8 +17,8 @@ class AddActivationFieldsToUsers extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropIfExists('activated_at');
-            $table->dropIfExists('activation_token');
+            $table->dropColumn('activated_at');
+            $table->dropColumn('activation_token');
         });
     }
 }


### PR DESCRIPTION
Change the method `dropIfExists` which refers to dropping a table to `dropColumn` as we only want to drop a column.
